### PR TITLE
fix: filtering dns server in agent instead of nftables

### DIFF
--- a/.github/workflows/bullfrog.yml
+++ b/.github/workflows/bullfrog.yml
@@ -133,6 +133,11 @@ jobs:
             exit 1;
           fi;
 
+          if timeout 5 dig @8.8.8.8 www.google.com; then
+            echo 'Expected 'dig @8.8.8.8 www.google.com' to fail, but it succeeded';
+            exit 1;
+          fi;
+
   test-block-but-allow-any-dns-requests:
     needs: build
     runs-on: ubuntu-22.04

--- a/.vagrant/provision.sh
+++ b/.vagrant/provision.sh
@@ -7,7 +7,12 @@ export DEBIAN_FRONTEND=noninteractive
 apt-get update
 
 # install curl and other dependencies
-apt-get install -y curl software-properties-common apt-utils jq golang
+apt-get install -y curl software-properties-common apt-utils jq make net-tools libnetfilter-queue-dev
+
+# install golang 1.22.4
+curl -OL https://go.dev/dl/go1.22.4.linux-amd64.tar.gz
+sudo tar -C /usr/local -xzf go1.22.4.linux-amd64.tar.gz
+echo 'export PATH=$PATH:/usr/local/go/bin' >> /home/vagrant/.bashrc
 
 # install Node.js 20.x
 curl -sL https://deb.nodesource.com/setup_20.x | bash -

--- a/agent/queue_block_with_dns.nft
+++ b/agent/queue_block_with_dns.nft
@@ -12,8 +12,8 @@ insert rule ip filter DOCKER-USER iifname "docker0" ip daddr @allowed_ips counte
 
 # Match DNS request (dest port 53) and enqueue to userspace
 # Block DNS queries for unallowed domains, preventing DNS exfiltration
-insert rule ip filter DOCKER-USER iifname "docker0" ip daddr 127.0.0.53 udp dport 53 counter queue num 0
-insert rule ip filter DOCKER-USER iifname "docker0" ip daddr 127.0.0.53 tcp dport 53 counter queue num 0
+insert rule ip filter DOCKER-USER iifname "docker0" udp dport 53 counter queue num 0
+insert rule ip filter DOCKER-USER iifname "docker0" tcp dport 53 counter queue num 0
 
 # Match DNS responses (source port 53) and enqueue to userspace
 insert rule ip filter DOCKER-USER oif "docker0" udp sport 53 counter queue num 0
@@ -41,8 +41,8 @@ table inet filter {
 
         # Match DNS request (dest port 53) and enqueue to userspace
         # Block DNS queries for unallowed domains, preventing DNS exfiltration
-        ip daddr 127.0.0.53 udp dport 53 queue num 0
-        ip daddr 127.0.0.53 tcp dport 53 queue num 0
+        udp dport 53 queue num 0
+        tcp dport 53 queue num 0
 
         # TODO: get rid of this
         # Allow established and related traffic

--- a/test/input.js
+++ b/test/input.js
@@ -5,7 +5,10 @@ process.env["INPUT_LOG-DIRECTORY"] = "/tmp/gha-agent/logs";
 process.env["INPUT_ALLOWED-DOMAINS"] = `
 *.google.com
 bing.com
+*.github.com
 `;
 
-// uncomment to test with local agent
+// uncomment to test with local agent or download release
 // process.env["INPUT_LOCAL-AGENT-PATH"] = "agent/agent";
+process.env["INPUT_AGENT-DOWNLOAD-BASE-URL"] =
+  "https://github.com/bullfrogsec/bullfrog/releases/download/";


### PR DESCRIPTION
Filtering in agent gives us better visibility for now, since we don't currently log blocked traffic from nftables