### PR TITLE
chore: add dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,11 +6,29 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-  - package-ecosystem: "npm" 
+    groups:
+      gha-minor-patch:
+        applies-to: version-updates
+        update-types:
+          - "patch"
+          - "minor"
+  - package-ecosystem: "npm"
     directory: "/action"
     schedule:
       interval: "weekly"
+    groups:
+      npm-minor-patch:
+        applies-to: version-updates
+        update-types:
+          - "patch"
+          - "minor"
   - package-ecosystem: "gomod"
     directory: "/agent"
     schedule:
       interval: "weekly"
+    groups:
+      go-minor-patch:
+        applies-to: version-updates
+        update-types:
+          - "patch"
+          - "minor"


### PR DESCRIPTION
Using groups in dependabot to ease the process of updating dependencies for minor and patch version updates.