### PR TITLE
ci: temporarily skip bullfrog until fix is released

### DIFF
--- a/.github/workflows/bullfrog.yml
+++ b/.github/workflows/bullfrog.yml
@@ -238,24 +238,24 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - name: Enable egress filtering
-        uses: bullfrogsec/bullfrog@931dc0cf68188ce1f6ddece4ab921bbf104fadc7 # v0.6.1
-        with:
-          egress-policy: block
-          allowed-domains: |
-            *.canonical.com
-            *.github.com
-            *.ubuntu.com
-            archivist.vagrantup.com
-            deb.nodesource.com
-            dl.google.com
-            download.docker.com
-            go.dev
-            objects.githubusercontent.com
-            packages.microsoft.com
-            vagrantcloud-files-production.s3-accelerate.amazonaws.com
-            vagrantcloud.com
-            www.google.com
+      # - name: Enable egress filtering
+      #   uses: bullfrogsec/bullfrog@931dc0cf68188ce1f6ddece4ab921bbf104fadc7 # v0.6.1
+      #   with:
+      #     egress-policy: block
+      #     allowed-domains: |
+      #       *.canonical.com
+      #       *.github.com
+      #       *.ubuntu.com
+      #       archivist.vagrantup.com
+      #       deb.nodesource.com
+      #       dl.google.com
+      #       download.docker.com
+      #       go.dev
+      #       objects.githubusercontent.com
+      #       packages.microsoft.com
+      #       vagrantcloud-files-production.s3-accelerate.amazonaws.com
+      #       vagrantcloud.com
+      #       www.google.com
 
       - name: Checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7


### PR DESCRIPTION
The agent has a bug (see #94 ) that causes the `apt-get update` command to often hangs. This is skipping the bullfrog step in the integration tests until the fix is released.