### PR TITLE
ci: fix virtualbox issue in test-integration job

### DIFF
--- a/.github/workflows/bullfrog.yml
+++ b/.github/workflows/bullfrog.yml
@@ -238,7 +238,7 @@ jobs:
 
   test-integration:
     needs: build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
 
     steps:
@@ -270,7 +270,9 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          sudo apt-get update
+          wget -O- https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
+          echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
+          sudo apt update
           sudo apt-get install --yes vagrant virtualbox
 
       - name: Start VM

--- a/.github/workflows/bullfrog.yml
+++ b/.github/workflows/bullfrog.yml
@@ -260,6 +260,7 @@ jobs:
             vagrantcloud-files-production.s3-accelerate.amazonaws.com
             vagrantcloud.com
             www.google.com
+            apt.releases.hashicorp.com
 
       - name: Checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7


### PR DESCRIPTION
Virtualbox is failing on ubuntu-22.04 since the latest runner image release ([ref](https://github.com/actions/runner-images/issues/10678)). Using ubuntu-24.04 for the test-integration job which is not impacted by the bug.